### PR TITLE
(webpack) - correctly pass vars for webpack 4

### DIFF
--- a/.changeset/lazy-steaks-know.md
+++ b/.changeset/lazy-steaks-know.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': patch
+---
+
+Fix variable passing

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -30,8 +30,8 @@ class ReloadPlugin {
 		});
 
 		compiler.hooks.compilation.tap(NAME, compilation => {
-			compilation.mainTemplate.hooks.require.tap(NAME, source =>
-				createRefreshTemplate(source)
+			compilation.mainTemplate.hooks.require.tap(NAME, (source, chunk, hash) =>
+				createRefreshTemplate(source, chunk, hash, compilation.mainTemplate)
 			);
 		});
 	}


### PR DESCRIPTION
This is an issue that was made when adding webpack 5 support @sulmanen this should fix your issue