### PR TITLE
(packages/vite) Concatenate prelude to avoid offsetting sourcemaps.

### DIFF
--- a/.changeset/blue-carrots-wink.md
+++ b/.changeset/blue-carrots-wink.md
@@ -1,0 +1,9 @@
+---
+'@prefresh/vite': patch
+---
+
+Concatenate inserted prelude to first line of script for sourcemaps
+
+Prelude and footer code blocks are not supplied to babel sourcemap generation and new lines in them will offset sourcemaps.
+This patch concatenates all of the prelude onto first line of module source to keep source map line mappings the same.
+Footer is unchanged, but since it's at the end of the file it will not offset any code.

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -54,7 +54,7 @@ module.exports = function prefreshPlugin(options = {}) {
 
           self.$RefreshReg$ = (type, id) => {
             self.__PREFRESH__.register(type, ${JSON.stringify(id)} + " " + id);
-          }
+          };
 
           self.$RefreshSig$ = () => {
             let status = 'begin';
@@ -66,23 +66,17 @@ module.exports = function prefreshPlugin(options = {}) {
             };
           };
         }
-        `;
+        `.replace(/[\n]+/gm, '');
 
       if (hasSig && !hasReg) {
         return {
-          code: `
-            ${prelude}
-            ${result.code}
-          `,
+          code: `${prelude}${result.code}`,
           map: result.map,
         };
       }
 
       return {
-        code: `
-        ${prelude}
-
-        ${result.code}
+        code: `${prelude}${result.code}
 
         if (import.meta.hot) {
           self.$RefreshReg$ = prevRefreshReg;


### PR DESCRIPTION
Sourcemaps are currently offset when using `@prefresh/vite`.

To not offset sourcemaps, vite prelude should not add lines to module output. This PR removes all line breaks in the prelude, and concatenates it to the first line of source. It also adds a semi in prelude source to not break syntax as one liner.

[Vites React fast refresh plugin does this](https://github.com/vitejs/vite/blob/main/packages/plugin-react-refresh/index.js#L151) and the fix is stolen from that code.

The bug and fix can be validated in the vite example site by setting a breakpoint in `app.jsx`.

This issue might be related: https://github.com/vitejs/vite/issues/2884

I probably did not do the changeset description correctly 😛. Happy for feedback on that text.

Also, I didn't manage to run the test-suite for the entire prefresh repo. I seem to have missing modules after yarn install.