### PR TITLE
(vite) - add support for 2.7

### DIFF
--- a/.changeset/chilly-singers-unite.md
+++ b/.changeset/chilly-singers-unite.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/vite": patch
+---
+
+Add support for 2.7.0

--- a/test/fixture/vite/package.json
+++ b/test/fixture/vite/package.json
@@ -10,7 +10,7 @@
     "@babel/core": "^7.9.6",
     "@prefresh/babel-plugin": "file:../../packages/babel",
     "@prefresh/vite": "file:../../packages/vite",
-    "vite": "2.0.3"
+    "vite": "^2.7.6"
   },
   "resolutions": {
 		"@prefresh/core": "file:../../packages/core",


### PR DESCRIPTION
Accidental commit to main adding support for 2.7 https://github.com/preactjs/prefresh/commit/fc3d060484845725f717a707704fd7525d810985