### PR TITLE
remove async component check

### DIFF
--- a/.changeset/pink-clouds-sparkle.md
+++ b/.changeset/pink-clouds-sparkle.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/core": patch
+---
+
+remove async component check

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -177,14 +177,6 @@ function replaceComponent(OldType, NewType, resetHookState) {
         }
       }
 
-      // Cleanup when an async component has thrown.
-      if (
-        (vnode[VNODE_DOM] && !document.contains(vnode[VNODE_DOM])) ||
-        (!vnode[VNODE_DOM] && !vnode[VNODE_CHILDREN])
-      ) {
-        location.reload();
-      }
-
       Component.prototype.forceUpdate.call(vnode[VNODE_COMPONENT]);
     }
   });


### PR DESCRIPTION
As alluded to in https://github.com/preactjs/prefresh/issues/404 this check does not work for shadow-dom/... it would be best to remove this and look for an alternative approach to reloading lazy loaded components

fixes #404