### PR TITLE
Vite suspense repro

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,16 +1,16 @@
-name: test
+name: test-preact-x
 
 on:
   pull_request:
     branches:
-      - '**'
+      - 'v1-preact-x'
   push:
     branches:
-      - main
+      - v1-preact-x
 
 jobs:
   build_test:
-    name: Build & Test
+    name: Build & Test Preact X
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,4 @@ packages/web-dev-server/runtime
 packages/web-dev-server/utils
 packages/snowpack/runtime
 packages/snowpack/utils
+test/fixture/**/yarn.lock

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -134,47 +134,37 @@ function replaceComponent(OldType, NewType, resetHookState) {
           [HOOKS_LIST]: [],
           [EFFECTS_LIST]: [],
         };
-      } else {
-        if (
-          vnode[VNODE_COMPONENT][COMPONENT_HOOKS] &&
-          vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST] &&
-          vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].length
-        ) {
-          vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].forEach(
-            possibleEffect => {
-              if (
-                possibleEffect[HOOK_CLEANUP] &&
-                typeof possibleEffect[HOOK_CLEANUP] === 'function'
-              ) {
-                possibleEffect[HOOK_CLEANUP]();
-              } else if (
-                possibleEffect[HOOK_ARGS] &&
-                possibleEffect[HOOK_VALUE] &&
-                Object.keys(possibleEffect).length === 3
-              ) {
-                const cleanupKey = Object.keys(possibleEffect).find(
-                  key => key !== HOOK_ARGS && key !== HOOK_VALUE
-                );
-                if (
-                  cleanupKey &&
-                  typeof possibleEffect[cleanupKey] == 'function'
-                )
-                  possibleEffect[cleanupKey]();
-              }
+      } else if (
+        vnode[VNODE_COMPONENT][COMPONENT_HOOKS] &&
+        vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST] &&
+        vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].length
+      ) {
+        vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].forEach(
+          possibleEffect => {
+            if (
+              possibleEffect[HOOK_CLEANUP] &&
+              typeof possibleEffect[HOOK_CLEANUP] === 'function'
+            ) {
+              possibleEffect[HOOK_CLEANUP]();
+            } else if (
+              possibleEffect[HOOK_ARGS] &&
+              possibleEffect[HOOK_VALUE] &&
+              Object.keys(possibleEffect).length === 3
+            ) {
+              const cleanupKey = Object.keys(possibleEffect).find(
+                key => key !== HOOK_ARGS && key !== HOOK_VALUE
+              );
+              if (cleanupKey && typeof possibleEffect[cleanupKey] == 'function')
+                possibleEffect[cleanupKey]();
             }
-          );
+          }
+        );
 
-          vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].forEach(
-            hook => {
-              if (
-                hook.__H &&
-                Array.isArray(hook.__H)
-              ) {
-                hook.__H = undefined;
-              }
-            }
-          );
-        }
+        vnode[VNODE_COMPONENT][COMPONENT_HOOKS][HOOKS_LIST].forEach(hook => {
+          if (hook.__H && Array.isArray(hook.__H)) {
+            hook.__H = undefined;
+          }
+        });
       }
 
       // Cleanup when an async component has thrown.

--- a/packages/core/src/runtime/vnode.js
+++ b/packages/core/src/runtime/vnode.js
@@ -31,8 +31,12 @@ options.vnode = vnode => {
     }
 
     vnode.type = foundType;
-    if (vnode[VNODE_COMPONENT]) {
-      vnode[VNODE_COMPONENT].constructor = foundType;
+    if (
+      vnode[VNODE_COMPONENT] &&
+      'prototype' in vnode.type &&
+      vnode.type.prototype.render
+    ) {
+      vnode[VNODE_COMPONENT].constructor = vnode.type;
     }
   }
 

--- a/packages/core/src/runtime/vnode.js
+++ b/packages/core/src/runtime/vnode.js
@@ -21,6 +21,15 @@ options.vnode = vnode => {
     }
 
     const foundType = getMappedVnode(vnode.type);
+    if (foundType !== vnode.type) {
+      const vnodes = vnodesForComponent.get(foundType);
+      if (!vnodes) {
+        vnodesForComponent.set(foundType, [vnode]);
+      } else {
+        vnodes.push(vnode);
+      }
+    }
+
     vnode.type = foundType;
     if (vnode[VNODE_COMPONENT]) {
       vnode[VNODE_COMPONENT].constructor = foundType;

--- a/test/constants.js
+++ b/test/constants.js
@@ -25,7 +25,7 @@ exports.binArgs = {
   next: ['dev', '-p', '3006'],
   snowpack: ['dev'],
   webpack: ['serve'],
-  'vite-preact-compat': ['-p', '3002'],
+  'vite-preact-compat': [],
   vite: [],
   nollup: ['-c', '--hot', '--content-base', 'public', '--port', '3003'],
   'web-dev-server': [],

--- a/test/constants.js
+++ b/test/constants.js
@@ -10,20 +10,22 @@ exports.integrations = [
 ];
 
 exports.bin = {
-  'next': dir =>
-    path.resolve(dir, `./node_modules/next/dist/bin/next`),
+  next: dir => path.resolve(dir, `./node_modules/next/dist/bin/next`),
   nollup: dir => path.resolve(dir, `./node_modules/nollup/lib/cli.js`),
   snowpack: dir => path.resolve(dir, `./node_modules/snowpack/index.bin.js`),
   vite: dir => path.resolve(dir, `./node_modules/vite/bin/vite.js`),
+  'vite-preact-compat': dir =>
+    path.resolve(dir, `./node_modules/vite/bin/vite.js`),
   'web-dev-server': dir =>
     path.resolve(dir, `./node_modules/@web/dev-server/dist/bin.js`),
   webpack: dir => path.resolve(dir, `./node_modules/webpack-cli/bin/cli.js`),
 };
 
 exports.binArgs = {
-  'next': ['dev', '-p', '3006'],
+  next: ['dev', '-p', '3006'],
   snowpack: ['dev'],
   webpack: ['serve'],
+  'vite-preact-compat': ['-p', '3002'],
   vite: [],
   nollup: ['-c', '--hot', '--content-base', 'public', '--port', '3003'],
   'web-dev-server': [],
@@ -31,18 +33,20 @@ exports.binArgs = {
 
 exports.goMessage = {
   vite: 'running',
+  'vite-preact-compat': 'running',
   snowpack: 'Server started',
   webpack: 'successfully',
   nollup: 'Compiled',
-  'next': 'successfully',
+  next: 'successfully',
   'web-dev-server': 'started',
 };
 
 exports.defaultPort = {
   vite: 3000,
+  'vite-preact-compat': 3002,
   webpack: 3001,
   nollup: 3003,
   snowpack: 3004,
   'web-dev-server': 3005,
-  'next': 3006,
+  next: 3006,
 };

--- a/test/fixture/vite-preact-compat/index.html
+++ b/test/fixture/vite-preact-compat/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Vite App</title>
+</head>
+<body>
+  <div id="app"></div>
+  <script type="module" src="./main.jsx"></script>
+</body>
+</html>

--- a/test/fixture/vite-preact-compat/main.jsx
+++ b/test/fixture/vite-preact-compat/main.jsx
@@ -1,0 +1,4 @@
+import { render, createElement as h } from 'preact/compat'
+import { App } from './src/app'
+
+render(<App />, document.getElementById('app'))

--- a/test/fixture/vite-preact-compat/package.json
+++ b/test/fixture/vite-preact-compat/package.json
@@ -1,0 +1,19 @@
+{
+  "scripts": {
+    "dev": "vite"
+  },
+  "dependencies": {
+    "goober": "^2.0.36",
+    "preact": "^10.5.7"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.9.6",
+    "@prefresh/babel-plugin": "file:../../packages/babel",
+    "@prefresh/vite": "file:../../packages/vite",
+    "vite": "^2.7.13"
+  },
+  "resolutions": {
+		"@prefresh/core": "file:../../packages/core",
+		"@prefresh/utils": "file:../../packages/utils"
+  }
+}

--- a/test/fixture/vite-preact-compat/src/app.jsx
+++ b/test/fixture/vite-preact-compat/src/app.jsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense, useState, createElement as h, Fragment } from 'preact/compat';
+
+const Test1Lazy = lazy(() => import('./test1.jsx'));
+const Test2Lazy = lazy(() => import('./test2.jsx'));
+
+export function App() {
+  const [show, setShow] = useState(true);
+
+  const toggle = () => {
+    setShow(!show);
+  };
+
+  return (
+    <>
+      <Suspense fallback={<div>Loading</div>}>
+        {show ? <Test1Lazy /> : <Test2Lazy />}
+      </Suspense>
+      <button className='toggle' onClick={toggle}>Toggle</button>
+    </>
+  );
+}

--- a/test/fixture/vite-preact-compat/src/test1.jsx
+++ b/test/fixture/vite-preact-compat/src/test1.jsx
@@ -1,0 +1,5 @@
+import { createElement as h } from 'preact/compat';
+
+export default function Test1() {
+  return <h2 className="test-1">Test 1</h2>;
+}

--- a/test/fixture/vite-preact-compat/src/test2.jsx
+++ b/test/fixture/vite-preact-compat/src/test2.jsx
@@ -1,5 +1,5 @@
 import { createElement as h } from 'preact/compat';
 
 export default function Test2() {
-  return <h2 className="test-3">Test 2</h2>;
+  return <h2 className="test-2">Test 2</h2>;
 }

--- a/test/fixture/vite-preact-compat/src/test2.jsx
+++ b/test/fixture/vite-preact-compat/src/test2.jsx
@@ -1,0 +1,5 @@
+import { createElement as h } from 'preact/compat';
+
+export default function Test2() {
+  return <h2 className="test-3">Test 2</h2>;
+}

--- a/test/fixture/vite-preact-compat/vite.config.js
+++ b/test/fixture/vite-preact-compat/vite.config.js
@@ -1,6 +1,9 @@
 import prefresh from '@prefresh/vite';
 
 export default {
+  server: {
+    port: 3002,
+  },
   esbuild: {
     jsxFactory: 'h',
     jsxFragment: 'Fragment'

--- a/test/fixture/vite-preact-compat/vite.config.js
+++ b/test/fixture/vite-preact-compat/vite.config.js
@@ -1,0 +1,12 @@
+import prefresh from '@prefresh/vite';
+
+export default {
+  esbuild: {
+    jsxFactory: 'h',
+    jsxFragment: 'Fragment'
+  },
+  optimizeDeps: {
+    include: ['preact/hooks', 'preact/compat', 'preact']
+  },
+	plugins: [prefresh()]
+};

--- a/test/suspense.test.js
+++ b/test/suspense.test.js
@@ -88,6 +88,17 @@ describe('Suspense', () => {
     await page.goto('http://localhost:' + defaultPort[integration]);
   });
 
+  const getEl = async selectorOrEl => {
+    return typeof selectorOrEl === 'string'
+      ? await page.$(selectorOrEl)
+      : selectorOrEl;
+  };
+
+  const getText = async selectorOrEl => {
+    const el = await getEl(selectorOrEl);
+    return el ? el.evaluate(el => el.textContent) : null;
+  };
+
   /**
    * Bug reproduction
    *

--- a/test/suspense.test.js
+++ b/test/suspense.test.js
@@ -1,0 +1,127 @@
+const fs = require('fs-extra');
+const path = require('path');
+const execa = require('execa');
+const puppeteer = require('puppeteer');
+const {
+  expectByPolling,
+  getFixtureDir,
+  getTempDir,
+  timeout,
+} = require('./utils');
+const { bin, binArgs, goMessage, defaultPort } = require('./constants');
+
+const TIMEOUT = 1000;
+
+describe('Suspense', () => {
+  const integration = 'vite-preact-compat';
+  let devServer, browser, page, serverConsoleListener;
+
+  const browserConsoleListener = msg => {
+    console.log('[BROWSER LOG]: ', msg);
+  };
+
+  jest.setTimeout(100000);
+
+  afterAll(async () => {
+    if (process.env.DEBUG)
+      page.removeListener('console', browserConsoleListener);
+
+    if (browser) await browser.close();
+    if (devServer) {
+      devServer.kill('SIGTERM', {
+        forceKillAfterTimeout: 0,
+      });
+    }
+
+    try {
+      await fs.remove(getTempDir(integration));
+    } catch (e) {}
+  });
+
+  beforeAll(async () => {
+    await timeout(2000);
+    try {
+      await fs.remove(getTempDir(integration));
+    } catch (e) {}
+
+    await fs.copy(getFixtureDir(integration), getTempDir(integration), {
+      filter: file => !/dist|node_modules/.test(file),
+    });
+
+    await execa('yarn', { cwd: getTempDir(integration) });
+
+    browser = await puppeteer.launch({
+      args: ['--no-sandbox', '--disable-setuid-sandbox'],
+    });
+    page = await browser.newPage();
+
+    devServer = execa(
+      bin[integration](getTempDir(integration)),
+      binArgs[integration],
+      {
+        cwd: getTempDir(integration),
+      }
+    );
+
+    await new Promise(resolve => {
+      devServer.stdout.on(
+        'data',
+        (serverConsoleListener = data => {
+          console.log('[SERVER LOG]: ', data.toString());
+          if (data.toString().match(goMessage[integration])) {
+            resolve();
+          }
+        })
+      );
+
+      devServer.stderr.on(
+        'data',
+        (serverConsoleListener = data => {
+          console.log('[ERROR SERVER LOG]: ', data.toString());
+        })
+      );
+    });
+
+    page = await browser.newPage();
+    if (process.env.DEBUG) page.on('console', browserConsoleListener);
+
+    await page.goto('http://localhost:' + defaultPort[integration]);
+  });
+
+  /**
+   * Bug reproduction
+   *
+   * - change text in test1.jsx
+   * - press button twice
+   * - change text again --> won't go through
+   */
+  test('Can make change to lazy loaded components', async () => {
+    const button = await page.$('.toggle');
+    const text1 = await page.$('.test-1');
+    await expectByPolling(() => getText(text1), 'Test 1');
+
+    await updateFile('src/test1.jsx', content =>
+      content.replace('Test 1', 'Test 1!!!!')
+    );
+
+    await timeout(TIMEOUT);
+    await expectByPolling(() => getText(text1), 'Test 1!!!');
+
+    await button.click();
+    await timeout(TIMEOUT);
+
+    const text2 = await page.$('.test-2');
+    await expectByPolling(() => getText(text2), 'Test 2');
+
+    await button.click();
+    await timeout(TIMEOUT);
+
+    await expectByPolling(() => getText(text1), 'Test 1!!!');
+
+    await updateFile('src/test1.jsx', content =>
+      content.replace('Test 1!!!', 'Test 1!')
+    );
+    await timeout(TIMEOUT);
+    await expectByPolling(() => getText(text1), 'Test 1!');
+  });
+});


### PR DESCRIPTION
Fixes #433
Resolved #438

The issue

```
page loads
Test1 has identity1 --> saved in lazy
We make adjustement --> identity2
Switch to Test2
Switch to Test1
lazy renders with identity1 because of saved comp
options,vnode maps this to identity2
We make adjustement --> identity3
```

Now we can see that identity1 will have a VNode and map to identity2 but the types we are getting for a hot-refresh are 2 and 3 which we can’t relate to one another