### PR TITLE
Fix importing @prefresh/webpack from ES modules

### DIFF
--- a/.changeset/short-buckets-leave.md
+++ b/.changeset/short-buckets-leave.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': patch
+---
+
+Fix ES module import

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -5,6 +5,7 @@
   "type": "commonjs",
   "exports": {
     ".": {
+      "import": "./src/index.js",
       "require": "./src/index.js"
     },
     "./package.json": "./package.json"


### PR DESCRIPTION
This is an additional fix for #284 and fixes an error like this:

```
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: No "exports" main defined in node_modules/@prefresh/webpack/package.json imported from webpack.config.mjs
```

Looks like the other packages already have this. Only the webpack one is missing it.