### PR TITLE
Fix createContext ID's in object properties

### DIFF
--- a/packages/babel/src/index.mjs
+++ b/packages/babel/src/index.mjs
@@ -475,7 +475,9 @@ export default function (babel, opts = {}) {
           return;
 
         let id = '';
-        if (t.isVariableDeclarator(path.parentPath)) {
+        if (t.isObjectProperty(path.parentPath)) {
+          id += '__' + path.parent.key.name;
+        } else if (t.isVariableDeclarator(path.parentPath)) {
           id += '$' + path.parent.id.name;
         } else if (t.isAssignmentExpression(path.parentPath)) {
           if (t.isIdentifier(path.parent.left)) {


### PR DESCRIPTION
As per [this slack report](https://preact.slack.com/archives/C3NMBSJKH/p1666302979633359), the following code is converted to assignments to the same context ID.

**input:**

```js
const contexts = {
  foo: createContext(),
  bar: createContext(),
};
```

**output:**

```js
const contexts = {
  foo: createContext._17pejbx || (createContext._17pejbx = createContext()),
  bar: createContext._17pejbx || (createContext._17pejbx = createContext())
};
```

This PR detects when `createContext()` is invoked within an object property and includes the key in the ID. It likely breaks for computed keys, and can still cause collisions for nested keys.