### PR TITLE
Fix vnode DOM not existing

### DIFF
--- a/.changeset/gentle-pillows-beam.md
+++ b/.changeset/gentle-pillows-beam.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/core": patch
+---
+
+Add guard for undefined parentDom

--- a/packages/core/src/index.js
+++ b/packages/core/src/index.js
@@ -54,7 +54,7 @@ function replaceComponent(OldType, NewType, resetHookState) {
   pendingUpdates = pendingUpdates.filter(p => p[0] !== OldType);
 
   vnodes.forEach(vnode => {
-    if (!vnode.__c.__P) return;
+    if (!vnode.__c || !vnode.__c.__P) return;
     // update the type in-place to reference the new component
     vnode.type = NewType;
 


### PR DESCRIPTION
I'm getting this error:
```
Uncaught (in promise) TypeError: Cannot read properties of null (reading '__P')
    at index.js+app+app:57:20
    at Array.forEach (<anonymous>)
    at Object.replaceComponent (index.js+app+app:56:10)
```

I couldn't trace on how to minimally reproduce the error but it happens consistently

It could be an edge case bug or maybe it's my naive way of implementing live reload, it's more or less like so:
```js
const reload = useImporter(file.href)

const original = await import(reload.url + FILE_POSTFIX)
const previous = await reload.import(false)
let uncached

try {
  uncached = await reload.import(true)
} catch (error) {
  await handleEdgeCases(error)
}

const modules = Object.keys(original)
  .concat(Object.keys(previous))
  .filter(uniques)

for (const name of modules) {
  if (!uncached[name]) continue

  window.__PREFRESH__.replaceComponent(original[name], uncached[name], true)
  window.__PREFRESH__.replaceComponent(previous[name], uncached[name], true)
}
```

I'm always resetting the state there, and I didn't implement the signature comparison because it's too complex, but this has been working perfectly