### PR TITLE
Fix type @prefresh/vite type resolution

### DIFF
--- a/.changeset/thirty-apples-shake.md
+++ b/.changeset/thirty-apples-shake.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': patch
+---
+
+Fix type type resolution for `type: "module"` projects

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -4,7 +4,10 @@
   "main": "src/index.js",
   "types": "index.d.ts",
   "exports": {
-    ".": "./src/index.js",
+    ".": {
+      "types": "./index.d.ts",
+      "require": "./src/index.js"
+    },
     "./package.json": "./package.json"
   },
   "modes": {


### PR DESCRIPTION
Fixes https://github.com/preactjs/prefresh/issues/518. As documented in https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing, when using the newer TypeScript module resolution formats, you need to include a `"types"` export condition. I've added that for the Vite package, which seems to be the only one with any types exposed.