### PR TITLE
fix: Incorrect default export of Vite plugin types under TS's Node16 module resolution

### DIFF
--- a/.changeset/fluffy-horses-crash.md
+++ b/.changeset/fluffy-horses-crash.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': patch
+---
+
+Fix for incorrect default export of types under TS's Node16 module resolution

--- a/packages/vite/index.d.ts
+++ b/packages/vite/index.d.ts
@@ -1,7 +1,7 @@
 import { FilterPattern } from '@rollup/pluginutils';
 import { Plugin } from 'vite';
 
-export interface Options {
+interface Options {
   parserPlugins?: readonly string[];
   include?: FilterPattern;
   exclude?: FilterPattern;
@@ -9,4 +9,4 @@ export interface Options {
 
 declare const prefreshPlugin: (options?: Options) => Plugin;
 
-export default prefreshPlugin;
+export = prefreshPlugin;


### PR DESCRIPTION
https://arethetypeswrong.github.io/?p=%40prefresh%2Fvite%402.4.4

The `Options` interface is a casualty here that I'm not sure can be avoided -- I did a little searching but it seems it'd be unavoidable. Do use `Options`? Seems like it'd be a pretty uncommon need.