### PR TITLE
fix: Only run Vite plugin on J/TSX files

### DIFF
--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -19,7 +19,7 @@ module.exports = function prefreshPlugin(options = {}) {
           : options && options.ssr === true;
       if (
         shouldSkip ||
-        !/\.(t|j)sx?$/.test(id) ||
+        !/\.(t|j)sx$/.test(id) ||
         id.includes('node_modules') ||
         id.includes('?worker') ||
         !filter(id) ||


### PR DESCRIPTION
Fixes https://github.com/vitejs/vite/pull/15262, I think. Need to check yet. Would also need to land in preset-vite, as we form a similar regex there and pass it in to the Prefresh plugin, but thought I'd address it here first.

Now, I'm not quite sure if this breaks anything... is there any need for Prefresh to run in `.js` or `.ts` files? Custom hooks? Dunno, unfortunately I'm not super familiar with how Prefresh actually facilitates HMR.

FWIW, this was the regex pattern in use (more or less) until #42, at which point it changed to the form we have now. I don't see any obvious context to it, so it might've just been a (relatively harmless in all fairness) accidental change?