### PR TITLE
feat: use resolve path

### DIFF
--- a/.changeset/eight-peaches-listen.md
+++ b/.changeset/eight-peaches-listen.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/webpack": patch
+---
+
+feat: In the Monrepo project, @prefresh/core might be hoisted to the top level, and the actual path can be obtained through resolution.

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -148,7 +148,7 @@ class ReloadPlugin {
       }
       case 5: {
         const dependency = webpack.EntryPlugin.createDependency(
-          '@prefresh/core',
+          require.resolve('@prefresh/core'),
           { name: '@prefresh/core' }
         );
         compiler.hooks.make.tapAsync(NAME, (compilation, callback) => {


### PR DESCRIPTION
In the Monrepo project, @prefresh/core might be hoisted to the top level, and the actual path can be obtained through resolution.