### PR TITLE
fixes "could not resolve runtime.js" error within prefresh/nollup

### DIFF
--- a/.changeset/thin-plums-taste.md
+++ b/.changeset/thin-plums-taste.md
@@ -1,0 +1,5 @@
+---
+"@prefresh/nollup": patch
+---
+
+fixes "could not resolve runtime.js" error within prefresh/nollup

--- a/packages/nollup/package.json
+++ b/packages/nollup/package.json
@@ -8,6 +8,10 @@
       "require": "./src/index.js",
       "import": "./src/wrapper.mjs"
     },
+    "./src/runtime.js": {
+      "require": "./src/runtime.js",
+      "import": "./src/runtime.js"
+    },	
     "./package.json": "./package.json"
   },
   "scripts": {


### PR DESCRIPTION
Fixed an error that occurs when importing `@prefresh/nollup` by building a project via nollup. The problem is described in more detail [here](https://github.com/PepsRyuu/nollup/issues/245)