### PR TITLE
fix: Support `.cjs` & `.mjs` extensions in Vite plugin

### DIFF
--- a/.changeset/beige-trainers-marry.md
+++ b/.changeset/beige-trainers-marry.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': patch
+---
+
+Support `.cjs` and `.mjs` file extensions in Vite plugin

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -19,7 +19,7 @@ module.exports = function prefreshPlugin(options = {}) {
           : options && options.ssr === true;
       if (
         shouldSkip ||
-        !/\.(t|j)sx?$/.test(id) ||
+        !/\.(c|m)?(t|j)sx?$/.test(id) ||
         id.includes('node_modules') ||
         id.includes('?worker') ||
         !filter(id) ||


### PR DESCRIPTION
Closes https://github.com/preactjs/preset-vite/issues/128

Happy to forgo `.cjs` support here -- thought I'd add it to start with, but can remove it if it's not something we want to support.