### PR TITLE
chore: Specify `execa` devDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint": "8.42.0",
     "eslint-config-developit": "^1.2.0",
     "eslint-config-prettier": "^8.8.0",
+    "execa": "^5.1.1",
     "fs-extra": "^11.1.1",
     "husky": "^8.0.3",
     "jest": "^29.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       eslint-config-prettier:
         specifier: ^8.8.0
         version: 8.8.0(eslint@8.42.0)
+      execa:
+        specifier: ^5.1.1
+        version: 5.1.1
       fs-extra:
         specifier: ^11.1.1
         version: 11.1.1


### PR DESCRIPTION
`execa` is used as part of the test suite, and while not specifying it doesn't immediately cause problems here, it is tripping up the ecosystem-ci I'm writing. This seemed like a reasonable enough of a thing to correct, however, as right now the test suite is relying on transient copies of `execa` to be lying around for use.

---

Essentially, as `execa` is not specified as a dependency, pnpm is able to resolve it from other places outside of the prefresh project (depending on directory structure and whatnot). `execa` is a Sindre package that went ESM-only in v6, so pulling anything newer obviously chokes up the `require()`s used here. Explicitly specifying it corrects pnpm's resolution, ensuring we only use a compatible v5.

