### PR TITLE
fix: Disable Prefresh plugin if `server.hmr` is set to `false`

### DIFF
--- a/.changeset/shaggy-apples-roll.md
+++ b/.changeset/shaggy-apples-roll.md
@@ -2,4 +2,4 @@
 '@prefresh/vite': patch
 ---
 
-Ensures plugin does not run alongside Vitest. Plugin will be limited to only running in development mode.
+Ensures plugin does not run alongside Vitest, fixing an issue that may occur when using mocks/fakes.

--- a/.changeset/shaggy-apples-roll.md
+++ b/.changeset/shaggy-apples-roll.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/vite': patch
+---
+
+Ensures plugin does not run alongside Vitest. Plugin will be limited to only running in development mode.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,8 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
+      - name: Setup Puppeteer
+        run: npx puppeteer browsers install chrome
       - name: Build packages
         run: yarn build
 

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -10,7 +10,7 @@ module.exports = function prefreshPlugin(options = {}) {
   return {
     name: 'prefresh',
     configResolved(config) {
-      shouldSkip = config.command === 'build' || config.isProduction;
+      shouldSkip = config.mode !== 'development';
     },
     async transform(code, id, options) {
       const ssr =

--- a/packages/vite/src/index.js
+++ b/packages/vite/src/index.js
@@ -10,7 +10,7 @@ module.exports = function prefreshPlugin(options = {}) {
   return {
     name: 'prefresh',
     configResolved(config) {
-      shouldSkip = config.mode !== 'development';
+      shouldSkip = config.isProduction || config.command === 'build' || config.server.hmr === false;
     },
     async transform(code, id, options) {
       const ssr =


### PR DESCRIPTION
Vitest slips through the check here as it masquerades as a normal dev run (`config.command == 'serve'`) causing [this issue outlined in Slack](https://preact.slack.com/archives/C3M9NTD16/p1738088721794319) which I'm not too sure is worth looking into separately -- module mocks & HMR seem like a bad combination.

Switched to copy [the check used in `vite-plugin-react`](https://github.com/vitejs/vite-plugin-react/blob/5a8c4bf79953792d69dae88126a6499f5ddd1707/packages/plugin-react/src/index.ts#L140-L143). It catches Vitest as it (Vitest) sets `server.hmr` to `false` and this also lets users disable prefresh via the `server.hmr` config option, which may be more convenient than say commenting it out or using the `prefreshEnabled` option via `@preact/preset-vite`.