### PR TITLE
Feat: add entryOptions as an option to the webpack entry

### DIFF
--- a/.changeset/vast-towns-hang.md
+++ b/.changeset/vast-towns-hang.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/webpack': patch
+---
+
+Add entryOptions option to the webpack entry

--- a/packages/webpack/src/index.js
+++ b/packages/webpack/src/index.js
@@ -20,6 +20,7 @@ class ReloadPlugin {
     this.options = {
       overlay: options && options.overlay,
       runsInNextJs: Boolean(options && options.runsInNextJs),
+      entryOptions: options && options.entryOptions,
     };
   }
 
@@ -155,7 +156,7 @@ class ReloadPlugin {
           compilation.addEntry(
             compiler.context,
             dependency,
-            undefined,
+            this.options.entryOptions,
             callback
           );
         });


### PR DESCRIPTION
Prefresh breaks if the app's entry points use webpack layers because the `preact` options the runtime loads will be a different file in memory than the one within the app, so `options.vnode` is not shared.

This PR allows passing in optional `entryOptions` for the specific prefresh entry. Otherwise, there's no way to intercept the entry options through another plugin hook. If these `options` were `entryData` instead 👨‍🍳 https://github.com/webpack/webpack/blob/3aa6b6bc3a6452b36df8eb8324b466a7d218e143/lib/Compilation.js#L2381

The only other alternative is to modify the `compilation.globalEntry.options.layer` but that will affect all entries.