### PR TITLE
Account for fragment clones

### DIFF
--- a/.changeset/dull-rules-greet.md
+++ b/.changeset/dull-rules-greet.md
@@ -1,0 +1,5 @@
+---
+'@prefresh/core': patch
+---
+
+Fix case where Fragment wrapped children loses all references

--- a/packages/core/src/runtime/vnode.js
+++ b/packages/core/src/runtime/vnode.js
@@ -1,5 +1,5 @@
 import { options } from 'preact';
-import { vnodesForComponent, mappedVNodes } from './vnodesForComponent';
+import { vnodesForComponent, mappedVNodes, lastSeen } from './vnodesForComponent';
 import { VNODE_COMPONENT } from '../constants';
 
 const getMappedVnode = type => {
@@ -53,6 +53,7 @@ const oldDiffed = options.diffed;
 options.diffed = vnode => {
   if (vnode && typeof vnode.type === 'function') {
     const vnodes = vnodesForComponent.get(vnode.type);
+    lastSeen.set(vnode.__v, vnode);
     if (vnodes) {
       const matchingDom = vnodes.filter(p => p.__c === vnode.__c);
       if (matchingDom.length > 1) {

--- a/packages/core/src/runtime/vnodesForComponent.js
+++ b/packages/core/src/runtime/vnodesForComponent.js
@@ -1,3 +1,4 @@
 // all vnodes referencing a given constructor
 export const vnodesForComponent = new WeakMap();
 export const mappedVNodes = new WeakMap();
+export const lastSeen = new Map();


### PR DESCRIPTION
In https://github.com/preactjs/preact/pull/4680 we fixed a memory leak where Preact would not be able to release top-level Fragments. This fix lead to us cloning the top-level Fragment and its children. Which lead us to this new place where we are suffering from having stale vnodes in memory. This banks on the `_original` property which is our VNode ID in Preact to give us the non-stale reference.