### PR TITLE
Add environment-gated npm publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,11 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    outputs:
+      has_changesets: ${{ steps.changesets.outputs.hasChangesets }}
     permissions:
       contents: write
-      id-token: write
-      issues: write
-      repository-projects: write
-      deployments: write
-      packages: write
+      issues: read
       pull-requests: write
     steps:
       - name: Checkout Repo
@@ -27,7 +25,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: "https://registry.npmjs.org"
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm
         run: npm install -g npm@11.11
@@ -54,7 +52,65 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile false --prefer-offline
 
-      - name: Release or Create Pull Request
+      - name: Create Release Pull Request
+        id: changesets
+        uses: changesets/action@v1.5.3
+        with:
+          version: pnpm run version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.has_changesets == 'false'
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/search?q=%40prefresh
+    permissions:
+      contents: write
+      id-token: write
+      issues: read
+      pull-requests: write
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Update npm
+        run: npm install -g npm@11.11
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 10
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-store
+        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Use pnpm store
+        uses: actions/cache@v4
+        id: pnpm-cache
+        with:
+          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+
+      - name: Install Dependencies
+        run: pnpm install --frozen-lockfile false --prefer-offline
+
+      - name: Publish packages
         uses: changesets/action@v1.5.3
         with:
           publish: pnpm changeset publish

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "build": "pnpm --filter @prefresh/web-dev-server build && pnpm --filter @prefresh/utils build && pnpm --filter @prefresh/babel-plugin build",
     "lint": "eslint src",
     "test": "jest --clearCache && jest --runInBand --forceExit --detectOpenHandles",
+    "version": "changeset version && pnpm install --lockfile-only --ignore-scripts",
     "prepare": "husky install"
   },
   "repository": {

--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -30,6 +30,7 @@
     "cjyes": "0.3.1"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -30,6 +30,7 @@
     "preact": "^10.0.0 || ^11.0.0-0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/nollup/package.json
+++ b/packages/nollup/package.json
@@ -41,6 +41,7 @@
     "preact": "^10.4.0 || ^11.0.0-0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/rolldown/package.json
+++ b/packages/rolldown/package.json
@@ -64,6 +64,7 @@
     }
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -30,6 +30,7 @@
     "cjyes": "0.3.1"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -53,6 +53,7 @@
     "vite": ">=2.0.0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/web-dev-server/package.json
+++ b/packages/web-dev-server/package.json
@@ -62,6 +62,7 @@
     "preact": "^10.4.0 || ^11.0.0-0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -39,6 +39,7 @@
     "webpack": "^4.0.0 || ^5.0.0"
   },
   "publishConfig": {
+    "access": "public",
     "provenance": true
   }
 }


### PR DESCRIPTION
## Summary
- Split release PR creation from npm publishing.
- Gate publishing behind the `npm` GitHub Environment with OIDC trusted publishing permissions.
- Add Changesets version script and public provenance publish config for `@prefresh/*` packages.

## Checks
- `git diff --check`
- `./node_modules/.bin/prettier --check .github/workflows/release.yml package.json packages/*/package.json`

## Note
- Requires configuring the `npm` environment and npm trusted publishing for this workflow.