### PR TITLE
Remove dependency cache from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,21 +36,8 @@ jobs:
           version: 10
           run_install: false
 
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Use pnpm store
-        uses: actions/cache@v4
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile false --prefer-offline
+        run: pnpm install --frozen-lockfile false
 
       - name: Create Release Pull Request
         id: changesets
@@ -94,21 +81,8 @@ jobs:
           version: 10
           run_install: false
 
-      - name: Get pnpm store directory
-        id: pnpm-store
-        run: echo "pnpm_cache_dir=$(pnpm store path)" >> $GITHUB_OUTPUT
-
-      - name: Use pnpm store
-        uses: actions/cache@v4
-        id: pnpm-cache
-        with:
-          path: ${{ steps.pnpm-store.outputs.pnpm_cache_dir }}
-          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-
-
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile false --prefer-offline
+        run: pnpm install --frozen-lockfile false
 
       - name: Publish packages
         uses: changesets/action@v1.5.3


### PR DESCRIPTION
Removes pnpm dependency caching from the release and publish jobs to avoid cache pollution risk in the publishing workflow.\n\nAlso drops `--prefer-offline` so installs do not prefer cached package data.\n\nTests not run; workflow-only change.