### PR TITLE
Upgrade pnpm supply-chain safeguards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10
+          version: 11.0.0
           run_install: false
 
       - name: Install Dependencies
@@ -78,7 +78,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10
+          version: 11.0.0
           run_install: false
 
       - name: Install Dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 10
+          version: 11.0.0
           run_install: false
 
       - name: Get pnpm store directory
@@ -47,10 +47,10 @@ jobs:
       - name: Setup Puppeteer
         run: npx puppeteer browsers install chrome
       - name: Build packages
-        run: yarn build
+        run: pnpm build
 
       - name: Run tests
-        run: yarn test
+        run: pnpm test
         env:
           CI: false
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,11 @@
 packages:
   - 'packages/*'
+
+minimumReleaseAge: 10080
+
+blockExoticSubdeps: true
+
+allowBuilds:
+  core-js: true
+  fsevents: true
+  puppeteer: true


### PR DESCRIPTION
## Summary
- upgrade pinned pnpm usage to pnpm 11
- configure a 7-day `minimumReleaseAge` window for installs
- explicitly block exotic transitive dependencies

## Why
Upgraded every repo to pnpm 11, so we inherit the ecosystem install-cooldown behaviour. It's not a fix on its own. It buys us a window.

## Testing
- Not run; config-only change.
