### PR TITLE
fix: use pnpm staged publishing

### DIFF
--- a/.github/scripts/stage-packages.mjs
+++ b/.github/scripts/stage-packages.mjs
@@ -1,43 +1,46 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { dirname, join, relative } from "node:path";
+import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
 
 const root = process.cwd();
-const config = JSON.parse(readFileSync(join(root, ".changeset/config.json"), "utf8"));
+const config = JSON.parse(
+  readFileSync(join(root, '.changeset/config.json'), 'utf8')
+);
 const ignored = new Set(config.ignore || []);
-const access = config.access || "public";
+const access = config.access || 'public';
 
 function readJson(path) {
-  return JSON.parse(readFileSync(path, "utf8"));
+  return JSON.parse(readFileSync(path, 'utf8'));
 }
 
 function packageJsonPathsFromPnpmWorkspace() {
-  const workspace = join(root, "pnpm-workspace.yaml");
+  const workspace = join(root, 'pnpm-workspace.yaml');
   if (!existsSync(workspace)) return [];
 
   const patterns = [];
-  for (const rawLine of readFileSync(workspace, "utf8").split(/\r?\n/)) {
+  for (const rawLine of readFileSync(workspace, 'utf8').split(/\r?\n/)) {
     const line = rawLine.trim();
-    if (!line.startsWith("- ")) continue;
-    const pattern = line.slice(2).replace(/^['\"]|['\"]$/g, "");
-    if (!pattern || pattern.startsWith("!")) continue;
+    if (!line.startsWith('- ')) continue;
+    const pattern = line.slice(2).replace(/^['\"]|['\"]$/g, '');
+    if (!pattern || pattern.startsWith('!')) continue;
     patterns.push(pattern);
   }
 
   const paths = [];
   for (const pattern of patterns) {
-    if (pattern.endsWith("/*")) {
+    if (pattern.endsWith('/*')) {
       const dir = join(root, pattern.slice(0, -2));
       if (!existsSync(dir)) continue;
       for (const entry of readdirSync(dir, { withFileTypes: true })) {
-        if (entry.isDirectory()) paths.push(join(dir, entry.name, "package.json"));
+        if (entry.isDirectory())
+          paths.push(join(dir, entry.name, 'package.json'));
       }
-    } else if (pattern.endsWith("/**")) {
+    } else if (pattern.endsWith('/**')) {
       // These workspaces are docs/examples and not published packages in this release flow.
       continue;
     } else {
-      paths.push(join(root, pattern, "package.json"));
+      paths.push(join(root, pattern, 'package.json'));
     }
   }
 
@@ -46,19 +49,24 @@ function packageJsonPathsFromPnpmWorkspace() {
 
 function packageJsonPaths() {
   const paths = new Set(packageJsonPathsFromPnpmWorkspace());
-  paths.add(join(root, "package.json"));
+  paths.add(join(root, 'package.json'));
   return [...paths].filter(existsSync);
 }
 
 function versionExists(name, version) {
-  const result = spawnSync("npm", ["view", `${name}@${version}`, "version", "--json"], {
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  const result = spawnSync(
+    'npm',
+    ['view', `${name}@${version}`, 'version', '--json'],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
 
   if (result.status === 0) return true;
   const output = `${result.stdout}\n${result.stderr}`;
-  if (output.includes("E404") || output.includes("No match found")) return false;
+  if (output.includes('E404') || output.includes('No match found'))
+    return false;
 
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
@@ -67,13 +75,48 @@ function versionExists(name, version) {
 
 function distTag(version) {
   const prerelease = version.match(/^[^-]+-([0-9A-Za-z-]+)/);
-  return prerelease ? prerelease[1] : "latest";
+  return prerelease ? prerelease[1] : 'latest';
+}
+
+function runGit(args) {
+  const result = spawnSync('git', args, {
+    cwd: root,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  process.stdout.write(result.stdout);
+  process.stderr.write(result.stderr);
+  if (result.status !== 0) process.exit(result.status || 1);
+}
+
+function hasLocalGitTag(tagName) {
+  const result = spawnSync(
+    'git',
+    ['rev-parse', '--verify', '--quiet', `refs/tags/${tagName}`],
+    {
+      cwd: root,
+      stdio: 'ignore',
+    }
+  );
+  return result.status === 0;
+}
+
+function createGitTag(tagName) {
+  if (hasLocalGitTag(tagName)) {
+    console.log(`Git tag ${tagName} already exists locally.`);
+  } else {
+    runGit(['tag', tagName, '-m', tagName]);
+  }
+
+  // changesets/action parses this line, then pushes the tag and creates the GitHub release.
+  console.log(`New tag: ${tagName}`);
 }
 
 const staged = [];
 for (const packageJsonPath of packageJsonPaths()) {
   const pkg = readJson(packageJsonPath);
-  if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name)) continue;
+  if (!pkg.name || !pkg.version || pkg.private || ignored.has(pkg.name))
+    continue;
   if (versionExists(pkg.name, pkg.version)) {
     console.log(`Skipping ${pkg.name}@${pkg.version}; already published.`);
     continue;
@@ -82,42 +125,49 @@ for (const packageJsonPath of packageJsonPaths()) {
   const packageDir = dirname(packageJsonPath);
   const tag = distTag(pkg.version);
   const args = [
-    "stage",
-    "publish",
+    'stage',
+    'publish',
     packageDir,
-    "--provenance",
-    "--access",
+    '--provenance',
+    '--access',
     pkg.publishConfig?.access || access,
-    "--tag",
+    '--tag',
     tag,
-    "--json",
+    '--json',
   ];
 
   console.log(`Staging ${pkg.name}@${pkg.version} with dist-tag ${tag}...`);
-  const result = spawnSync("npm", args, {
+  const result = spawnSync('pnpm', args, {
     cwd: root,
-    encoding: "utf8",
-    stdio: ["ignore", "pipe", "pipe"],
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
   });
   process.stdout.write(result.stdout);
   process.stderr.write(result.stderr);
   if (result.status !== 0) process.exit(result.status || 1);
 
   const stageId = result.stdout.match(/"stageId"\s*:\s*"([^"]+)"/)?.[1];
+  const tagName = `${pkg.name}@${pkg.version}`;
+  createGitTag(tagName);
+
   staged.push({
     name: pkg.name,
     version: pkg.version,
-    path: relative(root, packageDir) || ".",
+    path: relative(root, packageDir) || '.',
     stageId,
   });
 }
 
 if (staged.length === 0) {
-  console.log("No unpublished packages to stage.");
+  console.log('No unpublished packages to stage.');
 } else {
-  console.log("Staged packages:");
+  console.log('Staged packages:');
   for (const pkg of staged) {
-    console.log(`- ${pkg.name}@${pkg.version}${pkg.stageId ? ` (${pkg.stageId})` : ""}`);
+    console.log(
+      `- ${pkg.name}@${pkg.version}${pkg.stageId ? ` (${pkg.stageId})` : ''}`
+    );
   }
-  console.log("Approve staged packages with `npm stage approve <stage-id>` after review.");
+  console.log(
+    'Approve staged packages with `npm stage approve <stage-id>` after review.'
+  );
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
-          version: 11.0.0
+          version: 11.3.0
           run_install: false
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile false
+        run: pnpm install --frozen-lockfile
 
       - name: Create Release Pull Request
         id: changesets
@@ -85,15 +85,16 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3
         with:
-          version: 11.0.0
+          version: 11.3.0
           run_install: false
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile false
+        run: pnpm install --frozen-lockfile
 
       - name: Publish packages
         uses: changesets/action@e0145edc7d9d8679003495b11f87bd8ef63c0cba # v1.5.3
         with:
           publish: node .github/scripts/stage-packages.mjs
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Uses `pnpm stage publish` for the pnpm workspace publish path.
- Pins pnpm to 11.3.0 so the stage command is available.
- Preserves Changesets tag/GitHub release creation from the staging helper.
- Fixes the dependency install command to use the lockfile normally.

## Verification
- `node --check .github/scripts/stage-packages.mjs`
- `pnpm exec prettier --check .github/scripts/stage-packages.mjs .github/workflows/release.yml`
- Workflow YAML parsed locally.