### PR TITLE
fix(vite): resolve ESM types correctly under NodeNext and Deno

### DIFF
--- a/.changeset/clean-types-resolve.md
+++ b/.changeset/clean-types-resolve.md
@@ -1,0 +1,9 @@
+---
+'@prefresh/vite': patch
+---
+
+Fix type resolution under `moduleResolution: NodeNext` and Deno
+
+The `import` condition now resolves to a real ESM entry (`src/index.mjs`) with matching ESM type declarations (`index.d.mts` using `export default`), while `require` keeps the CommonJS declarations (`index.d.ts` using `export =`). Previously the ESM entry was typed with a CJS-style `export =` declaration, which TypeScript 6 / Deno 2.8.3+ reject as a hard error.
+
+Also inline the `FilterPattern` type instead of importing it from `@rollup/pluginutils`, whose types do not resolve under NodeNext.

--- a/packages/vite/index.d.mts
+++ b/packages/vite/index.d.mts
@@ -10,4 +10,4 @@ interface Options {
 
 declare const prefreshPlugin: (options?: Options) => Promise<PluginOption>;
 
-export = prefreshPlugin;
+export default prefreshPlugin;

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -6,9 +6,14 @@
   "types": "index.d.ts",
   "exports": {
     ".": {
-      "types": "./index.d.ts",
-      "require": "./src/index.js",
-      "import": "./src/index.js"
+      "import": {
+        "types": "./index.d.mts",
+        "default": "./src/index.mjs"
+      },
+      "require": {
+        "types": "./index.d.ts",
+        "default": "./src/index.js"
+      }
     },
     "./package.json": "./package.json"
   },
@@ -16,10 +21,9 @@
     "default": "src/index.js"
   },
   "files": [
-    "dist",
-    "runtime",
-    "utils",
-    "index.d.ts"
+    "src",
+    "index.d.ts",
+    "index.d.mts"
   ],
   "scripts": {
     "lint": "eslint src",

--- a/packages/vite/src/index.mjs
+++ b/packages/vite/src/index.mjs
@@ -1,0 +1,3 @@
+import prefreshPlugin from './index.js';
+
+export default prefreshPlugin;


### PR DESCRIPTION
## Problem

TypeScript 6.0 (shipped in Deno v2.8.3) rejects `export =` declarations resolved through an `exports.import` condition as a hard error, breaking `deno check` for every Fresh user depending on `@prefresh/vite`.

Fixes #625

## Changes

- Split the `exports` map per condition: `import` now resolves to a real ESM entry (`src/index.mjs`, a thin wrapper re-exporting the plugin as default) typed by a new `index.d.mts` using `export default`, while `require` keeps `src/index.js` typed by `index.d.ts` using `export =`.
- Inlined the `FilterPattern` type in both declaration files. `@rollup/pluginutils@4`'s types don't resolve under `moduleResolution: NodeNext` (TS7016), which broke any consumer type-checking without `skipLibCheck`.
- Cleaned the stale `files` array (`dist`/`runtime`/`utils` don't exist in this package) to `src`, `index.d.ts`, `index.d.mts`. The published tarball previously only worked because npm auto-includes the `main` file.