### PR TITLE
Use workspace:* identifiers for workspace dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 11.0.0
+          version: 11.3.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 11.3.0
+          version: 11.5.0
           run_install: false
 
       - name: Get pnpm store directory

--- a/packages/nollup/package.json
+++ b/packages/nollup/package.json
@@ -29,8 +29,8 @@
   },
   "homepage": "https://github.com/preactjs/prefresh#readme",
   "dependencies": {
-    "@prefresh/core": "^1.5.6",
-    "@prefresh/utils": "^1.2.1"
+    "@prefresh/core": "workspace:*",
+    "@prefresh/utils": "workspace:*"
   },
   "devDependencies": {
     "nollup": "^0.13.13",

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -36,15 +36,15 @@
   },
   "homepage": "https://github.com/preactjs/prefresh#readme",
   "dependencies": {
-    "@prefresh/core": "^1.5.0",
+    "@prefresh/core": "workspace:*",
     "@prefresh/rolldown": "workspace:*",
-    "@prefresh/utils": "^1.2.0",
+    "@prefresh/utils": "workspace:*",
     "@rollup/pluginutils": "^4.2.1",
     "rolldown": "^1.0.0-rc.12"
   },
   "devDependencies": {
     "@babel/core": "^7.22.1",
-    "@prefresh/babel-plugin": "^0.5.2",
+    "@prefresh/babel-plugin": "workspace:*",
     "preact": "^10.26.10",
     "vite": "^8.0.0"
   },

--- a/packages/web-dev-server/package.json
+++ b/packages/web-dev-server/package.json
@@ -46,9 +46,9 @@
   "homepage": "https://github.com/preactjs/prefresh#readme",
   "dependencies": {
     "@babel/core": "^7.22.1",
-    "@prefresh/babel-plugin": "^0.5.2",
-    "@prefresh/core": "^1.5.0",
-    "@prefresh/utils": "^1.2.0"
+    "@prefresh/babel-plugin": "workspace:*",
+    "@prefresh/core": "workspace:*",
+    "@prefresh/utils": "workspace:*"
   },
   "devDependencies": {
     "@web/dev-server": "^0.0.18",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/preactjs/prefresh#readme",
   "dependencies": {
-    "@prefresh/core": "^1.5.0",
-    "@prefresh/utils": "^1.2.0"
+    "@prefresh/core": "workspace:*",
+    "@prefresh/utils": "workspace:*"
   },
   "devDependencies": {
     "preact": "^10.26.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,11 +66,11 @@ importers:
         specifier: ^0.5.0
         version: 0.5.1
       '@prefresh/core':
-        specifier: ^1.5.6
-        version: 1.5.6(preact@10.26.10)
+        specifier: workspace:*
+        version: link:../core
       '@prefresh/utils':
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       nollup:
         specifier: ^0.13.13
@@ -104,14 +104,14 @@ importers:
   packages/vite:
     dependencies:
       '@prefresh/core':
-        specifier: ^1.5.0
-        version: 1.5.4(preact@10.26.10)
+        specifier: workspace:*
+        version: link:../core
       '@prefresh/rolldown':
         specifier: workspace:*
         version: link:../rolldown
       '@prefresh/utils':
-        specifier: ^1.2.0
-        version: 1.2.1
+        specifier: workspace:*
+        version: link:../utils
       '@rollup/pluginutils':
         specifier: ^4.2.1
         version: 4.2.1
@@ -123,8 +123,8 @@ importers:
         specifier: ^7.22.1
         version: 7.27.7
       '@prefresh/babel-plugin':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: workspace:*
+        version: link:../babel
       preact:
         specifier: ^10.26.10
         version: 10.26.10
@@ -138,14 +138,14 @@ importers:
         specifier: ^7.22.1
         version: 7.27.7
       '@prefresh/babel-plugin':
-        specifier: ^0.5.2
-        version: 0.5.2
+        specifier: workspace:*
+        version: link:../babel
       '@prefresh/core':
-        specifier: ^1.5.0
-        version: 1.5.4(preact@10.26.10)
+        specifier: workspace:*
+        version: link:../core
       '@prefresh/utils':
-        specifier: ^1.2.0
-        version: 1.2.1
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       '@web/dev-server':
         specifier: ^0.0.18
@@ -166,11 +166,11 @@ importers:
         specifier: ^0.5.0
         version: 0.5.1
       '@prefresh/core':
-        specifier: ^1.5.0
-        version: 1.5.4(preact@10.26.10)
+        specifier: workspace:*
+        version: link:../core
       '@prefresh/utils':
-        specifier: ^1.2.0
-        version: 1.2.1
+        specifier: workspace:*
+        version: link:../utils
     devDependencies:
       preact:
         specifier: ^10.26.10
@@ -624,22 +624,6 @@ packages:
   '@prefresh/babel-plugin@0.5.1':
     resolution: {integrity: sha512-uG3jGEAysxWoyG3XkYfjYHgaySFrSsaEb4GagLzYaxlydbuREtaX+FTxuIidp241RaLl85XoHg9Ej6E4+V1pcg==}
 
-  '@prefresh/babel-plugin@0.5.2':
-    resolution: {integrity: sha512-AOl4HG6dAxWkJ5ndPHBgBa49oo/9bOiJuRDKHLSTyH+Fd9x00shTXpdiTj1W41l6oQIwUOAgJeHMn4QwIDpHkA==}
-
-  '@prefresh/core@1.5.4':
-    resolution: {integrity: sha512-F7Sd/qnPX2QEkgiJr0hmImYjp6s85chlkR3Y9ncWVSMusN3UM9vMhQIdcYo/ugqxqo7cKH7Y7Oofrsimf7TWuQ==}
-    peerDependencies:
-      preact: ^10.0.0
-
-  '@prefresh/core@1.5.6':
-    resolution: {integrity: sha512-rmCc3ioWqUkWZo1/0T/dsz8gae52d1J1n/sHg3bnNzqyzD/TrBYlkBeE2i9L78DV3a99vuiUGz1oE+uliK1+4g==}
-    peerDependencies:
-      preact: ^10.0.0 || ^11.0.0
-
-  '@prefresh/utils@1.2.1':
-    resolution: {integrity: sha512-vq/sIuN5nYfYzvyayXI4C2QkprfNaHUQ9ZX+3xLD8nL3rWyzpxOm1+K7RtMbhd+66QcaISViK7amjnheQ/4WZw==}
-
   '@puppeteer/browsers@2.6.1':
     resolution: {integrity: sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==}
     engines: {node: '>=18'}
@@ -680,36 +664,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
     resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
     resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
     resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
@@ -787,56 +777,67 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -1422,7 +1423,7 @@ packages:
   basic-ftp@5.0.5:
     resolution: {integrity: sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==}
     engines: {node: '>=10.0.0'}
-    deprecated: Security vulnerability fixed in 5.2.0, please upgrade
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   batch@0.6.1:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
@@ -3287,24 +3288,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4781,6 +4786,7 @@ packages:
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-to-istanbul@9.3.0:
@@ -5717,18 +5723,6 @@ snapshots:
   '@oxc-project/types@0.122.0': {}
 
   '@prefresh/babel-plugin@0.5.1': {}
-
-  '@prefresh/babel-plugin@0.5.2': {}
-
-  '@prefresh/core@1.5.4(preact@10.26.10)':
-    dependencies:
-      preact: 10.26.10
-
-  '@prefresh/core@1.5.6(preact@10.26.10)':
-    dependencies:
-      preact: 10.26.10
-
-  '@prefresh/utils@1.2.1': {}
 
   '@puppeteer/browsers@2.6.1':
     dependencies:


### PR DESCRIPTION
## Problem

Internal package dependencies use explicit semver ranges, which complicates publishing — especially with staged publishing and `minimumReleaseAge`, where a just-published internal version isn't resolvable yet. It also caused workspace installs to resolve internal packages from the registry (e.g. `@prefresh/core@1.5.4`) instead of linking the local workspace packages.

## Changes

- Switch all internal `dependencies` and `devDependencies` in `@prefresh/nollup`, `@prefresh/vite`, `@prefresh/web-dev-server`, and `@prefresh/webpack` to `workspace:*`, which pnpm replaces with the exact local version at publish time. The lockfile now links these as workspace packages.
- `peerDependencies` on `@prefresh/babel-plugin` keep their loose ranges, since the workspace protocol would pin them to exact versions on publish.
- Bump pnpm to 11.3.0 in the test workflow to match the release workflow, as the lockfile is now written in the newer format.

The test fixtures need no changes: yarn's `resolutions` field overrides the `workspace:*` ranges before resolution, as already shown by the existing `@prefresh/rolldown` dependency.

Fixes #616